### PR TITLE
Enable PDF invoice download

### DIFF
--- a/invoice_app/urls.py
+++ b/invoice_app/urls.py
@@ -5,4 +5,5 @@ app_name = 'invoice_app'
 
 urlpatterns = [
     path('create_invoice/<int:id>/', views.create_invoice, name='create_invoice'),
+    path('invoice_pdf/<int:id>/', views.invoice_pdf, name='invoice_pdf'),
 ]

--- a/invoice_app/views.py
+++ b/invoice_app/views.py
@@ -4,95 +4,105 @@ from shopify_app.models import ShopifyOrder
 from facebook_app.models import Facebook_orders
 from .models import Order, Invoice
 from django.http import HttpResponse
+from django.template.loader import render_to_string
+import json
 import logging
 
+from weasyprint import HTML
+
 logger = logging.getLogger(__name__)
+
+
+def _get_order_data(order_id):
+    """Return normalized order data for the given ID from any platform."""
+    if WooCommerceOrder.objects.filter(pk=order_id).exists():
+        order_source = WooCommerceOrder.objects.get(pk=order_id)
+        raw = order_source.raw_data or {}
+        return {
+            'order_id': str(order_source.woo_id),
+            'customer_name': f"{order_source.billing_first_name} {order_source.billing_last_name}".strip(),
+            'customer_address': f"{order_source.billing_address_1}, {order_source.billing_address_2}, {order_source.billing_city}, {order_source.billing_state}, {order_source.billing_postcode}, {order_source.billing_country}",
+            'customer_email': order_source.billing_email,
+            'customer_phone': order_source.billing_phone,
+            'order_total': order_source.total_amount or 0,
+            'order_status': order_source.status,
+            'order_items': order_source.line_items_json or {},
+            'order_shipment_status': order_source.shipment_status,
+            'order_notes': order_source.customer_note,
+            'payment_method': raw.get('payment_method', ''),
+            'shipping_charge': raw.get('shipping_charge', 0),
+        }
+    if ShopifyOrder.objects.filter(pk=order_id).exists():
+        order_source = ShopifyOrder.objects.get(pk=order_id)
+        shipping = order_source.shipping_address_json or {}
+        raw = order_source.raw_data or {}
+        address = ", ".join(filter(None, [
+            shipping.get('address1'),
+            shipping.get('address2'),
+            shipping.get('city'),
+            shipping.get('province'),
+            shipping.get('zip'),
+            shipping.get('country'),
+        ]))
+        return {
+            'order_id': str(order_source.shopify_id),
+            'customer_name': shipping.get('name', '').strip(),
+            'customer_address': address,
+            'customer_email': order_source.email,
+            'customer_phone': shipping.get('phone'),
+            'order_total': order_source.total_price or 0,
+            'order_status': order_source.financial_status or '',
+            'order_items': order_source.line_items_json or {},
+            'order_shipment_status': order_source.shipment_status,
+            'order_notes': order_source.internal_notes,
+            'payment_method': raw.get('payment_method', ''),
+            'shipping_charge': raw.get('shipping_charge', 0),
+        }
+    if Facebook_orders.objects.filter(pk=order_id).exists():
+        order_source = Facebook_orders.objects.get(pk=order_id)
+        address = ", ".join(filter(None, [
+            order_source.address,
+            order_source.city,
+            order_source.state,
+            order_source.postcode,
+            order_source.country,
+        ]))
+        return {
+            'order_id': order_source.order_id,
+            'customer_name': f"{order_source.first_name} {order_source.last_name}".strip(),
+            'customer_address': address,
+            'customer_email': order_source.email,
+            'customer_phone': order_source.phone,
+            'order_total': order_source.total_amount or 0,
+            'order_status': order_source.status,
+            'order_items': order_source.products_json or {},
+            'order_shipment_status': order_source.shipment_status,
+            'order_notes': order_source.customer_note,
+            'payment_method': order_source.mode_of_payment or '',
+            'shipping_charge': order_source.shipment_amount or 0,
+        }
+    raise Exception("Order not found in any source")
+
+
+def _get_or_create_invoice(order_id):
+    order_data = _get_order_data(order_id)
+    invoice = Invoice.objects.filter(order__order_id=order_data['order_id']).first()
+    if invoice:
+        return invoice
+
+    order_obj, _ = Order.objects.get_or_create(order_id=order_data['order_id'], defaults=order_data)
+    invoice = Invoice.objects.create(order=order_obj)
+    return invoice
 
 
 def create_invoice(request, id):
     """Create an invoice for a given order ID across all platforms."""
     try:
-        order_data = None
-
-        if WooCommerceOrder.objects.filter(pk=id).exists():
-            order_source = WooCommerceOrder.objects.get(pk=id)
-            raw = order_source.raw_data or {}
-            order_data = {
-                'order_id': str(order_source.woo_id),
-                'customer_name': f"{order_source.billing_first_name} {order_source.billing_last_name}".strip(),
-                'customer_address': f"{order_source.billing_address_1}, {order_source.billing_address_2}, {order_source.billing_city}, {order_source.billing_state}, {order_source.billing_postcode}, {order_source.billing_country}",
-                'customer_email': order_source.billing_email,
-                'customer_phone': order_source.billing_phone,
-                'order_total': order_source.total_amount or 0,
-                'order_status': order_source.status,
-                'order_items': order_source.line_items_json or {},
-                'order_shipment_status': order_source.shipment_status,
-                'order_notes': order_source.customer_note,
-                'payment_method': raw.get('payment_method', ''),
-                'shipping_charge': raw.get('shipping_charge', 0),
-            }
-        elif ShopifyOrder.objects.filter(pk=id).exists():
-            order_source = ShopifyOrder.objects.get(pk=id)
-            shipping = order_source.shipping_address_json or {}
-            raw = order_source.raw_data or {}
-            address = ", ".join(filter(None, [
-                shipping.get('address1'),
-                shipping.get('address2'),
-                shipping.get('city'),
-                shipping.get('province'),
-                shipping.get('zip'),
-                shipping.get('country'),
-            ]))
-            order_data = {
-                'order_id': str(order_source.shopify_id),
-                'customer_name': shipping.get('name', '').strip(),
-                'customer_address': address,
-                'customer_email': order_source.email,
-                'customer_phone': shipping.get('phone'),
-                'order_total': order_source.total_price or 0,
-                'order_status': order_source.financial_status or '',
-                'order_items': order_source.line_items_json or {},
-                'order_shipment_status': order_source.shipment_status,
-                'order_notes': order_source.internal_notes,
-                'payment_method': raw.get('payment_method', ''),
-                'shipping_charge': raw.get('shipping_charge', 0),
-            }
-        elif Facebook_orders.objects.filter(pk=id).exists():
-            order_source = Facebook_orders.objects.get(pk=id)
-            address = ", ".join(filter(None, [
-                order_source.address,
-                order_source.city,
-                order_source.state,
-                order_source.postcode,
-                order_source.country,
-            ]))
-            order_data = {
-                'order_id': order_source.order_id,
-                'customer_name': f"{order_source.first_name} {order_source.last_name}".strip(),
-                'customer_address': address,
-                'customer_email': order_source.email,
-                'customer_phone': order_source.phone,
-                'order_total': order_source.total_amount or 0,
-                'order_status': order_source.status,
-                'order_items': order_source.products_json or {},
-                'order_shipment_status': order_source.shipment_status,
-                'order_notes': order_source.customer_note,
-                'payment_method': order_source.mode_of_payment or '',
-                'shipping_charge': order_source.shipment_amount or 0,
-            }
-        else:
-            raise Exception("Order not found in any source")
-
-        existing_invoice = Invoice.objects.filter(order__order_id=order_data['order_id']).first()
-        if existing_invoice:
-            logger.info(f"Invoice already exists with number: {existing_invoice.invoice_number}")
-            return HttpResponse(f"Invoice already exists with number: {existing_invoice.invoice_number}")
-
-        order_obj, _ = Order.objects.get_or_create(order_id=order_data['order_id'], defaults=order_data)
-
-        invoice = Invoice.objects.create(order=order_obj)
-        logger.info(f"Invoice created with number: {invoice.invoice_number}")
-        return HttpResponse(f"Invoice created successfully with number: {invoice.invoice_number}")
+        invoice = _get_or_create_invoice(id)
+        logger.info(f"Invoice ready with number: {invoice.invoice_number}")
+        return HttpResponse(
+            f"Invoice created successfully with number: {invoice.invoice_number}"
+        )
 
     except Exception as e:
         logger.error(f"Error creating invoice: {str(e)}")
@@ -101,3 +111,47 @@ def create_invoice(request, id):
 
 def create_company(request):
     shopify = 'data'
+
+
+def invoice_pdf(request, id):
+    """Return a PDF invoice for the given order ID."""
+    try:
+        invoice = _get_or_create_invoice(id)
+        order = invoice.order
+
+        items = order.order_items or []
+        if isinstance(items, str):
+            try:
+                items = json.loads(items)
+            except Exception:
+                items = []
+
+        subtotal = sum(
+            (float(item.get('price', 0)) * float(item.get('quantity', 1)))
+            for item in items
+        )
+        shipping_cost = float(order.shipping_charge or 0)
+        total = subtotal + shipping_cost
+
+        html_string = render_to_string(
+            'invoice/pdf_template.html',
+            {
+                'invoice': invoice,
+                'items': items,
+                'subtotal': subtotal,
+                'shipping_cost': shipping_cost,
+                'payment_method': order.payment_method,
+                'total': total,
+            },
+        )
+
+        pdf_file = HTML(string=html_string, base_url=request.build_absolute_uri()).write_pdf()
+        response = HttpResponse(pdf_file, content_type='application/pdf')
+        response[
+            'Content-Disposition'
+        ] = f'attachment; filename=invoice_{invoice.invoice_number}.pdf'
+        return response
+
+    except Exception as e:
+        logger.error(f"Error generating PDF: {str(e)}")
+        return HttpResponse(f"Error generating invoice PDF: {str(e)}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,3 +64,4 @@ wcwidth==0.2.13
 whitenoise==6.9.0
 WooCommerce==3.0.0
 zope.interface==7.2
+WeasyPrint==61.2

--- a/templates/invoice/create_invoice.html
+++ b/templates/invoice/create_invoice.html
@@ -47,19 +47,19 @@
                 <h2 class="text-2xl font-semibold text-gray-800 mb-4">INVOICE</h2>
                 <h3 class="font-semibold text-gray-700">Billed To</h3>
                 <address class="text-gray-600 not-italic mt-2">
-                    {{ invoice.customer.name }}<br>
-                    {{ invoice.customer.address|linebreaksbr }}<br>
-                    {{ invoice.customer.email }}<br>
-                    {{ invoice.customer.phone }}
+                    {{ invoice.order.customer_name }}<br>
+                    {{ invoice.order.customer_address|linebreaksbr }}<br>
+                    {{ invoice.order.customer_email }}<br>
+                    {{ invoice.order.customer_phone }}
                 </address>
             </div>
             <div class="w-full sm:w-auto sm:text-right">
                 <table class="text-sm w-full sm:w-auto">
                     <tbody>
                         <tr class="flex justify-between sm:table-row"><td class="font-semibold text-gray-700 pr-4 py-1">Invoice Number:</td><td class="text-gray-600 py-1">{{ invoice.invoice_number }}</td></tr>
-                        <tr class="flex justify-between sm:table-row"><td class="font-semibold text-gray-700 pr-4 py-1">Invoice Date:</td><td class="text-gray-600 py-1">{{ invoice.issue_date|date:"F j, Y" }}</td></tr>
-                        <tr class="flex justify-between sm:table-row"><td class="font-semibold text-gray-700 pr-4 py-1">Order Number:</td><td class="text-gray-600 py-1">{{ invoice.id }}</td></tr>
-                        <tr class="flex justify-between sm:table-row"><td class="font-semibold text-gray-700 pr-4 py-1">Order Date:</td><td class="text-gray-600 py-1">{{ invoice.created_at|date:"F j, Y" }}</td></tr>
+                        <tr class="flex justify-between sm:table-row"><td class="font-semibold text-gray-700 pr-4 py-1">Invoice Date:</td><td class="text-gray-600 py-1">{{ invoice.invoice_date|date:"F j, Y" }}</td></tr>
+                        <tr class="flex justify-between sm:table-row"><td class="font-semibold text-gray-700 pr-4 py-1">Order Number:</td><td class="text-gray-600 py-1">{{ invoice.order.order_id }}</td></tr>
+                        <tr class="flex justify-between sm:table-row"><td class="font-semibold text-gray-700 pr-4 py-1">Order Date:</td><td class="text-gray-600 py-1">{{ invoice.order.order_date|date:"F j, Y" }}</td></tr>
                         <tr class="flex justify-between sm:table-row"><td class="font-semibold text-gray-700 pr-4 py-1">Payment Method:</td><td class="text-gray-600 py-1">{{ payment_method }}</td></tr>
                     </tbody>
                 </table>
@@ -77,11 +77,11 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for item in invoice.items.all %}
+                        {% for item in items %}
                         <tr class="border-b border-gray-200">
                             <td class="p-3 text-gray-700">{{ item.description }}</td>
                             <td class="p-3 text-gray-700 text-center">{{ item.quantity }}</td>
-                            <td class="p-3 text-gray-700 text-right">₹{{ item.unit_price|floatformat:2 }}</td>
+                            <td class="p-3 text-gray-700 text-right">₹{{ item.price|floatformat:2 }}</td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/templates/invoice/pdf_template.html
+++ b/templates/invoice/pdf_template.html
@@ -96,10 +96,10 @@
                 <h2 style="font-size: 22px; font-weight: bold; margin: 0 0 10px 0;">INVOICE</h2>
                 <div class="font-bold" style="margin-bottom: 5px;">Billed To</div>
                 <div class="address-block">
-                    {{ invoice.customer.name }}<br>
-                    {{ invoice.customer.address|linebreaksbr }}<br>
-                    {{ invoice.customer.email }}<br>
-                    {{ invoice.customer.phone }}
+                    {{ invoice.order.customer_name }}<br>
+                    {{ invoice.order.customer_address|linebreaksbr }}<br>
+                    {{ invoice.order.customer_email }}<br>
+                    {{ invoice.order.customer_phone }}
                 </div>
             </td>
             <td style="width: 50%; vertical-align: middle;">
@@ -110,15 +110,15 @@
                     </tr>
                     <tr>
                         <td class="font-bold">Invoice Date:</td>
-                        <td class="text-right">{{ invoice.issue_date|date:"F j, Y" }}</td>
+                        <td class="text-right">{{ invoice.invoice_date|date:"F j, Y" }}</td>
                     </tr>
                     <tr>
                         <td class="font-bold">Order Number:</td>
-                        <td class="text-right">{{ invoice.id }}</td>
+                        <td class="text-right">{{ invoice.order.order_id }}</td>
                     </tr>
                     <tr>
                         <td class="font-bold">Order Date:</td>
-                        <td class="text-right">{{ invoice.created_at|date:"F j, Y" }}</td>
+                        <td class="text-right">{{ invoice.order.order_date|date:"F j, Y" }}</td>
                     </tr>
                     <tr>
                         <td class="font-bold">Payment Method:</td>
@@ -139,11 +139,11 @@
             </tr>
         </thead>
         <tbody>
-            {% for item in invoice.items.all %}
+            {% for item in items %}
             <tr>
                 <td>{{ item.description }}</td>
                 <td style="text-align: center;">{{ item.quantity }}</td>
-                <td class="text-right">₹{{ item.unit_price|floatformat:2 }}</td>
+                <td class="text-right">₹{{ item.price|floatformat:2 }}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/templates/woocommerce/order_list.html
+++ b/templates/woocommerce/order_list.html
@@ -104,7 +104,7 @@
                     <tbody>
                         {% for order in orders %}
                         <tr {% if order.is_overdue_highlight %} style="background-color:yellow; color:blue;" {% endif %}>
-                            <td><a class="order-details-view" href="{% url 'invoice_app:create_invoice' order.id %}">Download</a></td>
+                            <td><a class="order-details-view" href="{% url 'invoice_app:invoice_pdf' order.id %}">Download</a></td>
                             <td><a class="order-details-view" href="{% url 'order_detail' order.woo_id %}"><i class="fas fa-eye"></i> #{{ order.woo_id }}</a></td>                            
                             <td>{{ order.date_created_woo|date:"d-m-Y H:i"|default:"N/A" }}</td> {# Use woo date #}
                             <td>


### PR DESCRIPTION
## Summary
- add helper functions in invoice views for reuse
- implement invoice_pdf view using WeasyPrint
- expose invoice_pdf route and update orders list download link
- update invoice templates to use Order data
- add WeasyPrint dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc6c0ccb48321b59fedbace4fefda