### PR TITLE
Add project settings model with encryption

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -3,8 +3,11 @@
 import os
 import sys
 
-from dotenv import load_dotenv # <-- Add
-load_dotenv()                 # <-- Add
+try:
+    from dotenv import load_dotenv  # Optional environment variable support
+    load_dotenv()
+except Exception:
+    pass
 
 def main():
     """Run administrative tasks."""

--- a/nurseryproject/settings.py
+++ b/nurseryproject/settings.py
@@ -13,6 +13,15 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # --- Load Environment Variables ---
 load_dotenv(BASE_DIR / '.env')
 
+# --- Encryption Key for Settings App ---
+from cryptography.fernet import Fernet
+FIELD_ENCRYPTION_KEY = os.getenv('FIELD_ENCRYPTION_KEY')
+if not FIELD_ENCRYPTION_KEY:
+    FIELD_ENCRYPTION_KEY = Fernet.generate_key().decode()
+
+# --- Base URL for constructing webhook endpoints ---
+BASE_WEBHOOK_URL = os.getenv('BASE_WEBHOOK_URL', '')
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
@@ -55,6 +64,7 @@ INSTALLED_APPS = [
     'facebook_app',
     'whatsapp_app',
     'shipment_app',
+    'settings_app',
     'rest_framework',
 ]
 
@@ -108,6 +118,20 @@ WHATSAPP_ACCESS_TOKEN = os.getenv('WHATSAPP_ACCESS_TOKEN')
 WHATSAPP_PHONE_NUMBER_ID = os.getenv('WHATSAPP_PHONE_NUMBER_ID')
 WHATSAPP_VERIFY_TOKEN = os.getenv('WHATSAPP_VERIFY_TOKEN')
 WHATSAPP_APP_SECRET = os.getenv('WHATSAPP_APP_SECRET')
+
+# --- Construct full webhook URLs for reference ---
+WHATSAPP_WEBHOOK_ENDPOINT = '/whatsapp/webhook/'
+SHOPIFY_WEBHOOK_ENDPOINT = '/shopify/webhooks/receive-shopify-e5d4f3c2b1/'
+WOOCOMMERCE_WEBHOOK_ENDPOINT = '/woocommerce/webhooks/orders/receive-9a8b7c6d5e/'
+
+if BASE_WEBHOOK_URL:
+    WHATSAPP_WEBHOOK_URL = f"{BASE_WEBHOOK_URL.rstrip('/')}{WHATSAPP_WEBHOOK_ENDPOINT}"
+    SHOPIFY_WEBHOOK_URL = f"{BASE_WEBHOOK_URL.rstrip('/')}{SHOPIFY_WEBHOOK_ENDPOINT}"
+    WOOCOMMERCE_WEBHOOK_URL = f"{BASE_WEBHOOK_URL.rstrip('/')}{WOOCOMMERCE_WEBHOOK_ENDPOINT}"
+else:
+    WHATSAPP_WEBHOOK_URL = WHATSAPP_WEBHOOK_ENDPOINT
+    SHOPIFY_WEBHOOK_URL = SHOPIFY_WEBHOOK_ENDPOINT
+    WOOCOMMERCE_WEBHOOK_URL = WOOCOMMERCE_WEBHOOK_ENDPOINT
 
 
 

--- a/settings_app/__init__.py
+++ b/settings_app/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'settings_app.apps.SettingsAppConfig'

--- a/settings_app/admin.py
+++ b/settings_app/admin.py
@@ -1,3 +1,10 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import ProjectSetting
+
+
+@admin.register(ProjectSetting)
+class ProjectSettingAdmin(admin.ModelAdmin):
+    list_display = ("service_name", "webhook_path", "created_at", "updated_at")
+    readonly_fields = ("full_webhook_url",)
+

--- a/settings_app/migrations/0001_initial.py
+++ b/settings_app/migrations/0001_initial.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+import settings_app.models
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='ProjectSetting',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('service_name', models.CharField(max_length=100, unique=True)),
+                ('api_key', settings_app.models.EncryptedTextField()),
+                ('webhook_path', models.CharField(max_length=255)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                'verbose_name': 'Project Setting',
+                'verbose_name_plural': 'Project Settings',
+            },
+        ),
+    ]
+

--- a/settings_app/models.py
+++ b/settings_app/models.py
@@ -1,3 +1,53 @@
 from django.db import models
+from django.conf import settings
+from cryptography.fernet import Fernet
 
-# Create your models here.
+
+class EncryptedTextField(models.TextField):
+    """A TextField that transparently encrypts its value using Fernet."""
+
+    def _get_fernet(self) -> Fernet:
+        key = getattr(settings, "FIELD_ENCRYPTION_KEY", None)
+        if not key:
+            raise ValueError("FIELD_ENCRYPTION_KEY must be set in settings")
+        if isinstance(key, str):
+            key = key.encode()
+        return Fernet(key)
+
+    def from_db_value(self, value, expression, connection):
+        if value is None:
+            return value
+        f = self._get_fernet()
+        try:
+            return f.decrypt(value.encode()).decode()
+        except Exception:
+            return value
+
+    def get_prep_value(self, value):
+        if value is None:
+            return value
+        f = self._get_fernet()
+        return f.encrypt(str(value).encode()).decode()
+
+
+class ProjectSetting(models.Model):
+    """Stores credentials and webhook paths for external integrations."""
+
+    service_name = models.CharField(max_length=100, unique=True)
+    api_key = EncryptedTextField()
+    webhook_path = models.CharField(max_length=255)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "Project Setting"
+        verbose_name_plural = "Project Settings"
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return self.service_name
+
+    @property
+    def full_webhook_url(self) -> str:
+        base = getattr(settings, "BASE_WEBHOOK_URL", "")
+        return f"{base.rstrip('/')}{self.webhook_path}" if base else self.webhook_path
+


### PR DESCRIPTION
## Summary
- add encryption key settings and webhook URLs in `settings.py`
- add `settings_app` to project apps
- create `ProjectSetting` model with encrypted credential storage
- register `ProjectSetting` admin
- add migration for settings app
- make manage.py tolerate missing `python-dotenv`

## Testing
- `python manage.py makemigrations settings_app` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6852a2d7e1cc832195cfd4e12af4a5d4