### PR TITLE
Configure local Celery behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ logs/                  Application logs
    python manage.py runserver
    ```
 
+When `DEBUG` is set to `True` (the default in development), Celery tasks
+execute immediately in the same process. This allows the site to run locally
+without needing Redis or any Celery workers.
+
 For background tasks you also need Redis running and Celery workers:
 ```bash
 celery -A nurseryproject worker -l info

--- a/nurseryproject/settings.py
+++ b/nurseryproject/settings.py
@@ -283,10 +283,17 @@ CHANNEL_LAYERS = {
 }
 
 # Celery Configuration (Example)
-CELERY_BROKER_URL = f'redis://{REDIS_HOST}:{REDIS_PORT}/0' 
-CELERY_RESULT_BACKEND = f'redis://{REDIS_HOST}:{REDIS_PORT}/1' 
+CELERY_BROKER_URL = f'redis://{REDIS_HOST}:{REDIS_PORT}/0'
+CELERY_RESULT_BACKEND = f'redis://{REDIS_HOST}:{REDIS_PORT}/1'
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TIMEZONE = 'Asia/Kolkata'
 CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
+
+# When running the development server we often don't have Celery workers
+# running. Execute tasks locally in that case so the project can run
+# without Redis or a Celery worker.
+if DEBUG:
+    CELERY_TASK_ALWAYS_EAGER = True
+    CELERY_TASK_EAGER_PROPAGATES = True


### PR DESCRIPTION
## Summary
- run Celery tasks eagerly when DEBUG=True so a worker isn't needed in dev
- document that behaviour in the README

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6852a890eb74832194fa6c00abf56b8e